### PR TITLE
Django 1.10 compatibility

### DIFF
--- a/mezzanine_pagedown/urls.py
+++ b/mezzanine_pagedown/urls.py
@@ -1,7 +1,17 @@
-from django.conf.urls import patterns, url
+from django import VERSION
 
 from .views import MarkupPreview
 
-urlpatterns = patterns('',
-    url(r'^preview/$', MarkupPreview.as_view(), name='preview'),
-)
+
+if VERSION[1] > 9:
+    from django.conf.urls import url
+    urlpatterns = (
+        url(r'^preview/$', MarkupPreview.as_view(), name='preview'),
+    )    
+    
+else:
+    from django.conf.urls import patterns, url
+    urlpatterns = patterns('',
+        url(r'^preview/$', MarkupPreview.as_view(), name='preview'),
+    )
+


### PR DESCRIPTION
This checks for the version of Django installed and if >= 1.10 changes how the `url`'s are defined
