### PR TITLE
 Add Setting PAGEDOWN_USE_MEZZANINE_HTML_ESCAPE &  Support latest bleach

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,12 @@ How to Use
     Markdown to HTML, and respects Mezzanine's
     `RICHTEXT_ALLOWED_TAGS`, `RICHTEXT_ALLOWED_ATTRIBUTES`, and
     `RICHTEXT_ALLOWED_STYLES` settings.
-
+    
+    * NOTES:   
+    If you want to embed gist's code etc. in the iframe in the markdown text,  
+    please set `PAGEDOWN_USE_MEZZANINE_HTML_ESCAPE` to `True`.
+    mezzanine-pagedown provides Mezzanine's sanitizing after rendering Markdown to HTML
+    
  6. (Optional): Server-side previews:
 
      - In `settings.py`, enable server-side live previews in the editor:

--- a/mezzanine_pagedown/defaults.py
+++ b/mezzanine_pagedown/defaults.py
@@ -1,5 +1,16 @@
-from mezzanine.conf import register_setting
+"""
+Default settings for the ``mezzanine_pagedown`` app.
 
+Each of these can be overridden in your project's settings module, 
+just like regular Django settings. 
+The ``editable`` argument for each controls whether 
+the setting is editable via Django's admin.
+Thought should be given to how a setting is actually used before
+making it editable, as it may be inappropriate - for example settings
+that are only read during startup shouldn't be editable, since changing
+them would require an application reload.
+"""
+from mezzanine.conf import register_setting
 
 register_setting(
     name="PAGEDOWN_SERVER_SIDE_PREVIEW",
@@ -14,4 +25,12 @@ register_setting(
     description="A tuple specifying enabled python-markdown extensions.",
     editable=False,
     default=(),
+)
+
+register_setting(
+    name="PAGEDOWN_USE_MEZZANINE_HTML_ESCAPE",
+    description="Use MEZZANINE's HTML escape processing. "
+	            "When set to True, HTML escape of MEZZANINE according to RICH TEXT FILTER is done. ",
+    editable=False,
+    default=False,
 )

--- a/mezzanine_pagedown/defaults.py
+++ b/mezzanine_pagedown/defaults.py
@@ -34,3 +34,10 @@ register_setting(
     editable=False,
     default=False,
 )
+
+register_setting(
+    name="PAGEDOWN_MARKDOWN_FORMAT",
+    description="python-markdown's output format. ",
+    editable=False,
+    default="xhtml1",
+)

--- a/mezzanine_pagedown/filters.py
+++ b/mezzanine_pagedown/filters.py
@@ -9,15 +9,15 @@ from bleach import clean
 def _clean(html):
     if settings.PAGEDOWN_USE_MEZZANINE_HTML_ESCAPE:
         return escape(html)
-    else:
-        tags = settings.RICHTEXT_ALLOWED_TAGS
-        attrs = settings.RICHTEXT_ALLOWED_ATTRIBUTES
-        styles = settings.RICHTEXT_ALLOWED_STYLES
-        if LooseVersion('2.0') <= LooseVersion(bleach.__version__) and isinstance(attrs, tuple):
-            attrs = list(attrs)
+
+    tags = settings.RICHTEXT_ALLOWED_TAGS
+    attrs = settings.RICHTEXT_ALLOWED_ATTRIBUTES
+    styles = settings.RICHTEXT_ALLOWED_STYLES
+    if LooseVersion('2.0') <= LooseVersion(bleach.__version__) and isinstance(attrs, tuple):
+        attrs = list(attrs)
 
     return clean(html, tags=tags, attributes=attrs, strip=True,
-                 strip_comments=False, styles=styles)
+                strip_comments=False, styles=styles)
 
 
 def codehilite(content):

--- a/mezzanine_pagedown/filters.py
+++ b/mezzanine_pagedown/filters.py
@@ -1,6 +1,8 @@
 from mezzanine.conf import settings
 from mezzanine.utils.html import escape
 from markdown import markdown
+from distutils.version import LooseVersion
+import bleach
 from bleach import clean
 
 
@@ -11,8 +13,11 @@ def _clean(html):
         tags = settings.RICHTEXT_ALLOWED_TAGS
         attrs = settings.RICHTEXT_ALLOWED_ATTRIBUTES
         styles = settings.RICHTEXT_ALLOWED_STYLES
-        return clean(html, tags=tags, attributes=attrs, strip=True,
-                     strip_comments=False, styles=styles)
+        if LooseVersion('2.0') <= LooseVersion(bleach.__version__) and isinstance(attrs, tuple):
+            attrs = list(attrs)
+
+    return clean(html, tags=tags, attributes=attrs, strip=True,
+                 strip_comments=False, styles=styles)
 
 
 def codehilite(content):

--- a/mezzanine_pagedown/filters.py
+++ b/mezzanine_pagedown/filters.py
@@ -17,7 +17,7 @@ def _clean(html):
         attrs = list(attrs)
 
     return clean(html, tags=tags, attributes=attrs, strip=True,
-                strip_comments=False, styles=styles)
+                 strip_comments=False, styles=styles)
 
 
 def codehilite(content):

--- a/mezzanine_pagedown/filters.py
+++ b/mezzanine_pagedown/filters.py
@@ -1,15 +1,18 @@
 from mezzanine.conf import settings
-
+from mezzanine.utils.html import escape
 from markdown import markdown
 from bleach import clean
 
 
 def _clean(html):
-    tags = settings.RICHTEXT_ALLOWED_TAGS
-    attrs = settings.RICHTEXT_ALLOWED_ATTRIBUTES
-    styles = settings.RICHTEXT_ALLOWED_STYLES
-    return clean(html, tags=tags, attributes=attrs, strip=True,
-                 strip_comments=False, styles=styles)
+    if settings.PAGEDOWN_USE_MEZZANINE_HTML_ESCAPE:
+        return escape(html)
+    else:
+        tags = settings.RICHTEXT_ALLOWED_TAGS
+        attrs = settings.RICHTEXT_ALLOWED_ATTRIBUTES
+        styles = settings.RICHTEXT_ALLOWED_STYLES
+        return clean(html, tags=tags, attributes=attrs, strip=True,
+                     strip_comments=False, styles=styles)
 
 
 def codehilite(content):

--- a/mezzanine_pagedown/filters.py
+++ b/mezzanine_pagedown/filters.py
@@ -24,7 +24,7 @@ def codehilite(content):
     """
     Renders content using markdown with the codehilite extension.
     """
-    return _clean(markdown(content, ['codehilite',]))
+    return _clean(markdown(content, ['codehilite',]), output_format=settings.PAGEDOWN_MARKDOWN_FORMAT)
 
 
 def plain(content):
@@ -38,7 +38,7 @@ def extra(content):
     """
     Renders content using markdown extra.
     """
-    return _clean(markdown(content, ['extra',]))
+    return _clean(markdown(content, ['extra',], output_format=settings.PAGEDOWN_MARKDOWN_FORMAT))
 
 
 def custom(content):
@@ -47,4 +47,4 @@ def custom(content):
     ``settings.PAGEDOWN_MARKDOWN_EXTENSIONS``.
     """
     return _clean(markdown(content,
-            extensions=settings.PAGEDOWN_MARKDOWN_EXTENSIONS))
+            extensions=settings.PAGEDOWN_MARKDOWN_EXTENSIONS,output_format=settings.PAGEDOWN_MARKDOWN_FORMAT))


### PR DESCRIPTION
I am using mezzanine-pagedown on my blog.
Fixed the following 2 points that using and noticed.


1. I tried to embed gist's iframe in an article, but now html escape is always executed, so embedding of iframe did not work.
For this reason, we added an option to perform escape according to Mezzanine's filter level.

1. when filter was operated using the latest version of bleach, the following error occurred.
```console
  File "/usr/local/lib/python2.7/site-packages/mezzanine_pagedown/filters.py", line 43, in custom
    extensions = settings.PAGEDOWN_MARKDOWN_EXTENSIONS))
  File "/usr/local/lib/python2.7/site-packages/mezzanine_pagedown/filters.py", line 14, in _clean
    return clean (html, tags = tags, attributes = attrs, strip = True, strip_comments = False, styles = styles)
  File "/usr/local/lib/python2.7/site-packages/bleach/__init__.py", line 84, in clean
    return cleaner.clean (text)
  File "/usr/local/lib/python2.7/site-packages/bleach/sanitizer.py", line 217, in clean
    allowed_svg_properties = [],
  File "/usr/local/lib/python2.7/site-packages/bleach/sanitizer.py", line 372, in __init__
    self.attr_filter = attribute_filter_factory (attributes)
  File "/usr/local/lib/python2.7/site-packages/bleach/sanitizer.py", line 265, in attribute_filter_factory
    raise ValueError ('attributes needs to be a callable, a list or a dict')
ValueError: attributes needs to be a callable, a list or a dict
```
In order to avoid the above error, we added processing to support bleach 2.0 or higher.